### PR TITLE
Update Docker.md

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -8,11 +8,7 @@ Go to Settings of Docker, then go to Docker Engine tab. Set the `registry-mirror
 
 ```json
 "registry-mirrors": [
-    "https://registry.docker-cn.com",
-    "http://hub-mirror.c.163.com",
-    "https://3laho3y3.mirror.aliyuncs.com",
-    "http://f1361db2.m.daocloud.io",
-    "https://mirror.ccs.tencentyun.com"
+    "https://dockerproxy.com"
   ]
 ```
 
@@ -23,11 +19,7 @@ Add a file `/etc/docker/daemon.json`, and add the following content into the fil
 ```json
 {
 "registry-mirrors": [
-    "https://registry.docker-cn.com",
-    "http://hub-mirror.c.163.com",
-    "https://3laho3y3.mirror.aliyuncs.com",
-    "http://f1361db2.m.daocloud.io",
-    "https://mirror.ccs.tencentyun.com"
+    "https://dockerproxy.com"
   ]
 }
 ```
@@ -36,3 +28,4 @@ Add a file `/etc/docker/daemon.json`, and add the following content into the fil
 
 - [Settings for Docker on Windows in China](https://blog.csdn.net/qq_35976271/article/details/91362620)
 - [Docker Speedup in China](https://www.cnblogs.com/nhdlb/p/12567154.html)
+- [set docker proxy](https://dockerproxy.com/docs)


### PR DESCRIPTION
更新 docker 镜像站点, 之前的大部分镜像已不能使用, 更新为 https://dockerproxy.com